### PR TITLE
Update workbreakdef.h for Table 3 of Unicode Standard Annex 29, Rev. 23

### DIFF
--- a/src/wordbreakdef.h
+++ b/src/wordbreakdef.h
@@ -50,7 +50,7 @@
 
 /**
  * Word break classes.  This is a direct mapping of Table 3 of Unicode
- * Standard Annex 29, Revision 17.
+ * Standard Annex 29, Revision 23.
  */
 enum WordBreakClass
 {
@@ -68,6 +68,9 @@ enum WordBreakClass
 	WBP_Numeric,
 	WBP_ExtendNumLet,
 	WBP_Regional,
+	WBP_Hebrew,
+	WBP_Single,
+	WBP_Double,
 	WBP_Any
 };
 


### PR DESCRIPTION
This commit fixes the fact that command

``` bash
make wordbreakdata
```

is failing due to recent changes of the _Unicode Annex 29, Table 3_. 
