### PR TITLE
Expose low level line breaking API

### DIFF
--- a/src/linebreak.c
+++ b/src/linebreak.c
@@ -562,18 +562,6 @@ utf32_t lb_get_next_char_utf32(
 	return s[(*ip)++];
 }
 
-/**
- * Context representing internal state of the linebreaking algorithm
- */
-struct LineBreakContext
-{
-	const char *lang;                    /**< Language name */
-	struct LineBreakProperties *lbpLang; /**< Pointer to line breaking properties */
-	enum LineBreakClass lbcCur;          /**< Breaking class of current codepoint */
-	enum LineBreakClass lbcNew;          /**< Breaking class of next codepoint */
-	enum LineBreakClass lbcLast;         /**< Breaking class of last codepoint */
-};
-
 /* Special treatment for the first character */
 static inline void lb_init_breaking_class(
 		struct LineBreakContext* lbpCtx)
@@ -662,7 +650,7 @@ static inline int lb_classify_break_lookup(
  * @param[in,out]  lbpCtx       line breaking context
  * @param[in]      lang         language of the input
  */
-static void lb_init_break_context(
+void lb_init_break_context(
 		struct LineBreakContext* lbpCtx,
 		utf32_t ch,
 		const char* lang)
@@ -685,9 +673,9 @@ static void lb_init_break_context(
  *                                      #LINEBREAK_MUSTBREAK, #LINEBREAK_ALLOWBREAK,
  *                                      #LINEBREAK_NOBREAK, or #LINEBREAK_INSIDEACHAR
  */
-static char lb_process_next_char(
+char lb_process_next_char(
 		struct LineBreakContext* lbpCtx,
-		const utf32_t ch )
+		utf32_t ch )
 {
 	int brk;
 

--- a/src/linebreakdef.h
+++ b/src/linebreakdef.h
@@ -150,3 +150,25 @@ void set_linebreaks(
 		const char *lang,
 		char *brks,
 		get_next_char_t get_next_char);
+
+// Low level API - can be used for incremental "on-the-fly" linebreaking analysis
+
+/**
+ * Context representing internal state of the linebreaking algorithm
+ */
+struct LineBreakContext
+{
+	const char *lang;                                       /**< Language name */
+	struct LineBreakProperties *lbpLang;/**< Pointer to line breaking properties */
+	enum LineBreakClass lbcCur;                     /**< Breaking class of current codepoint */
+	enum LineBreakClass lbcNew;                     /**< Breaking class of next codepoint */
+	enum LineBreakClass lbcLast;            /**< Breaking class of last codepoint */
+};
+
+void lb_init_break_context( 
+	struct LineBreakContext* lbpCtx,
+	utf32_t ch,
+	const char* lang );
+char lb_process_next_char(
+	struct LineBreakContext* lbpCtx, 
+	utf32_t ch );


### PR DESCRIPTION
Hi,
first of all I'd like to thank you for a really helpful piece of software.

To give you a context - I am implementing a text shaping engine in c++ and I was trying to implement a line breaking iterator (conceptually similar to [one implemented in ICU](http://www.icu-project.org/apiref/icu4c/classicu_1_1BreakIterator.html)). 

When I was trying to utilize your library I faced a problem that it performs the line breaking algorithm all at once - in a single call while my iterator needs to process the input in small chunks (by individual code points).

So this pull request contains my approach expose the low level API (three character level functions) to client:

```
- lb_init_break_context() 
- lb_handle_first_char() 
- lb_handle_next_char()
```

... and re-implement the `set_linebreaks()` function on top of that.

Please, feel free to reject this request if my approach is too intrusive or simply does not fit to your taste.
(I'd be by no means offended and would be quite happy to stay on my fork if necessary).
Also I am a C++ programmer so my C skills may not be very good, but I tried hard to stick with your coding style.

Kind Regards
Filodej
