### PR TITLE
add per_code_point variants of utf8 and utf16 functions

### DIFF
--- a/src/linebreak.h
+++ b/src/linebreak.h
@@ -69,6 +69,10 @@ void set_linebreaks_utf16(
         const utf16_t *s, size_t len, const char *lang, char *brks);
 void set_linebreaks_utf32(
         const utf32_t *s, size_t len, const char *lang, char *brks);
+size_t set_linebreaks_utf8_per_code_point(
+        const utf8_t *s, size_t len, const char *lang, char *brks);
+size_t set_linebreaks_utf16_per_code_point(
+        const utf16_t *s, size_t len, const char *lang, char *brks);
 int is_line_breakable(utf32_t char1, utf32_t char2, const char *lang);
 
 #ifdef __cplusplus

--- a/src/linebreakdef.h
+++ b/src/linebreakdef.h
@@ -114,6 +114,12 @@ enum LineBreakClass
     LBP_XX          /**< Unknown */
 };
 
+enum BreakOutputType
+{
+    LBOT_PER_CODE_UNIT,
+    LBOT_PER_CODE_POINT
+};
+
 /**
  * Struct for entries of line break properties.  The array of the
  * entries \e must be sorted.
@@ -166,10 +172,11 @@ void lb_init_break_context(
 int lb_process_next_char(
         struct LineBreakContext *lbpCtx,
         utf32_t ch);
-void set_linebreaks(
+size_t set_linebreaks(
         const void *s,
         size_t len,
         const char *lang,
+        enum BreakOutputType outputType,
         char *brks,
         get_next_char_t get_next_char);
 


### PR DESCRIPTION
output contained in brks array is per code-point instead of per code-unit

implements #30 