### PR TITLE
lb_get_char_class() function added

### DIFF
--- a/src/linebreak.c
+++ b/src/linebreak.c
@@ -715,6 +715,12 @@ int lb_process_next_char(
 
     return brk;
 }
+enum LineBreakClass lb_get_char_class(
+        const struct LineBreakContext *lbpCtx,
+        utf32_t ch)
+{
+    return get_char_lb_class_lang(ch, lbpCtx->lbpLang);
+}
 
 /**
  * Sets the line breaking information for a generic input string.

--- a/src/linebreakdef.h
+++ b/src/linebreakdef.h
@@ -174,6 +174,9 @@ void lb_init_break_context(
 int lb_process_next_char(
         struct LineBreakContext *lbpCtx,
         utf32_t ch);
+enum LineBreakClass lb_get_char_class(
+        const struct LineBreakContext *lbpCtx,
+        utf32_t ch);
 size_t set_linebreaks(
         const void *s,
         size_t len,


### PR DESCRIPTION
Added public function lb_get_char_class() that returns the Unicode character class for the specified code and context.

The purpose of the function is indicated in #39.